### PR TITLE
Upgrade pyrogram package

### DIFF
--- a/server.py
+++ b/server.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from aiohttp import web
 from aiohttp.web import Response, StreamResponse
 from pyrogram.file_id import FileId
-from pyrogram.errors import MessageNotFound
+from pyrogram.errors import MessageIdInvalid
 
 from config import Config
 from database import FileStats, update_file_stats
@@ -533,7 +533,7 @@ class WebServer:
                 
             return response
             
-        except MessageNotFound:
+        except MessageIdInvalid:
             return web.Response(text="File not found", status=404)
         except Exception as e:
             self.logger.error(f"File serving error: {e}", exc_info=True)


### PR DESCRIPTION
Replace `MessageNotFound` with `MessageIdInvalid` in `server.py` to fix an `ImportError`.

The `MessageNotFound` exception does not exist in Pyrogram. `MessageIdInvalid` is the correct exception to handle cases where a message or file is not found due to an invalid ID.

---
<a href="https://cursor.com/background-agent?bcId=bc-3952fade-6697-440f-8099-77c7fdca9013">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3952fade-6697-440f-8099-77c7fdca9013">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

